### PR TITLE
cmake: fix multiarch installation path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,8 @@ message(STATUS "install prefix: " ${CMAKE_INSTALL_PREFIX})
 
 #------------------------- Compilation settings -------------------------
 
+include(GNUInstallDirs)
+
 # -fPIC in xos way
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
@@ -354,15 +356,13 @@ else()
 endif()
 
 # Install libraries
-install(TARGETS camhal camhal_static
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        )
+install(TARGETS camhal camhal_static)
 
 # Install package config file
 configure_file(${PROJECT_SOURCE_DIR}/cmake/libcamhal.pc.cmakein
                ${PROJECT_SOURCE_DIR}/libcamhal.pc @ONLY)
-install(FILES libcamhal.pc DESTINATION lib/pkgconfig)
+install(FILES libcamhal.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 endif() #NOT CAL_BUILD
 

--- a/cmake/libcamhal.pc.cmakein
+++ b/cmake/libcamhal.pc.cmakein
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@CMAKE_INSTALL_PREFIX@/lib
-includedir=@CMAKE_INSTALL_PREFIX@/include/libcamhal
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/libcamhal
 
 Name: libcamhal
 Description: Camera HAL Library


### PR DESCRIPTION
This includes GNUInstallDirs to probe for the correct 3-tripplet path settings, e.g. `/usr/lib/x86_64-linux-gnu`.

Signed-off-by: You-Sheng Yang <vicamo@gmail.com>