### PR TITLE
cmake: build libcamhal.so from static lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,9 +237,9 @@ endif() #ENABLE_SANDBOXING
     set(LIBCAMHAL_SRCS ${LIBCAMHAL_SRCS} ${IIO_SRCS})
 
 # Add libcamhal using the specified sources
-add_library(camhal SHARED ${LIBCAMHAL_SRCS})
 add_library(camhal_static STATIC ${LIBCAMHAL_SRCS})
 set_target_properties(camhal_static PROPERTIES OUTPUT_NAME "camhal")
+add_library(camhal SHARED $<TARGET_OBJECTS:camhal_static>)
 
 #---------------------------- Link settings ----------------------------
 target_link_libraries(camhal ${CMAKE_DL_LIBS})


### PR DESCRIPTION
This PR builds libcamhal.so directly from already built libcamhal.a to save some compile time and to make sure static/shared libraries have the same object code.