### PR TITLE
Correct plugin path and reduce the debug messages

### DIFF
--- a/src/hal/hal_adaptor/CMakeLists.txt
+++ b/src/hal/hal_adaptor/CMakeLists.txt
@@ -66,7 +66,7 @@ add_compile_options(-Wall -Werror
 add_definitions(-D__STDC_FORMAT_MACROS
                 -DHAVE_PTHREADS
                 -DHAVE_LINUX_OS
-                -DCAMHAL_PLUGIN_DIR=\"${CMAKE_INSTALL_LIBDIR}/libcamhal/plugins/\"
+                -DCAMHAL_PLUGIN_DIR=\"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libcamhal/plugins/\"
                 )
 
 set(HAL_ADAPTOR_LD_FLAGS "-fPIE -fPIC -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Wl,-z,relro -Wl,-z,now")

--- a/src/hal/hal_adaptor/HalAdaptor.cpp
+++ b/src/hal/hal_adaptor/HalAdaptor.cpp
@@ -75,7 +75,7 @@ static void load_camera_hal_library() {
         LOGE("%s, Not support the PCI device %s for hal adaptor API", __func__, pciID);
         return VOID_VALUE;
     }
-    LOGI("%s, the library name: %s", __func__, libName.c_str());
+    LOG1("%s, the library name: %s", __func__, libName.c_str());
 
     gCameraHalLib = dlopen(libName.c_str(), RTLD_NOW);
     CheckAndLogError(!gCameraHalLib, VOID_VALUE, "%s, failed to open library: %s, error: %s",


### PR DESCRIPTION
- dfsg: hal: lower library name printing loudness
- dfsg: cmake: correct plugin path