### PR TITLE
Remove the predefined _FORTIFY_SOURCE level in source code, and follo…

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -57,18 +57,32 @@ jobs:
       - name: Build test for ${{ matrix.version }} on ${{ matrix.os }}
         timeout-minutes: 10
         run: |
+          case "${{ matrix.os }}" in
+            ("ubuntu:24.04")
+              fortify_level=3
+              ;;
+            ("ubuntu:22.04"|"ubuntu:20.04")
+              fortify_level=2
+              ;;
+            (*)
+              echo "${{ matrix.os }} is unsupported yet. Please find the default fortify_level in /usr/share/perl5/Dpkg/Vendor/Ubuntu.pm or /usr/share/perl5/Dpkg/Vendor/Debian.pm."
+              exit 1
+              ;;
+          esac
           cd "${GITHUB_WORKSPACE}/hal"
 
           mkdir build && cd build
           if [ "${{ matrix.version }}" = "hal" ]; then
             cmake -DCMAKE_BUILD_TYPE=Release \
+              "-DCMAKE_CXX_FLAGS=-D_FORTIFY_SOURCE=$fortify_level" \
               ../src/hal/hal_adaptor;
           else
             cmake -DCMAKE_BUILD_TYPE=Release \
+              "-DCMAKE_CXX_FLAGS=-D_FORTIFY_SOURCE=$fortify_level" \
               -DIPU_VER="${{ matrix.version }}" \
               -DUSE_PG_LITE_PIPE=ON \
               -DUSE_HAL_ADAPTOR=ON \
               ..
           fi
-          make
+          VERBOSE=1 make
           make install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,8 +84,6 @@ set (CMAKE_CXX_STANDARD 11)
 add_compile_options(-Wall -Werror
                     -fstack-protector
                     -fPIE -fPIC
-                    -U_FORTIFY_SOURCE
-                    -D_FORTIFY_SOURCE=2
                     -DDCHECK_ALWAYS_ON
                     -Wformat -Wformat-security
                     )
@@ -152,7 +150,7 @@ include_directories(include
                     src/image_process
                     )
 
-set(LIBCAMHAL_LD_FLAGS "-fPIE -fPIC -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Wl,-z,relro -Wl,-z,now")
+set(LIBCAMHAL_LD_FLAGS "-fPIE -fPIC -Wformat -Wformat-security -Wl,-z,relro -Wl,-z,now")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${LIBCAMHAL_LD_FLAGS}")
 
 add_subdirectory(src)

--- a/src/hal/hal_adaptor/CMakeLists.txt
+++ b/src/hal/hal_adaptor/CMakeLists.txt
@@ -58,8 +58,6 @@ set (CMAKE_CXX_STANDARD 11)
 add_compile_options(-Wall -Werror
                     -fstack-protector
                     -fPIE -fPIC
-                    -U_FORTIFY_SOURCE
-                    -D_FORTIFY_SOURCE=2
                     -DDCHECK_ALWAYS_ON
                     -Wformat -Wformat-security
                     )
@@ -70,7 +68,7 @@ add_definitions(-D__STDC_FORMAT_MACROS
                 -DCAMHAL_PLUGIN_DIR=\"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libcamhal/plugins/\"
                 )
 
-set(HAL_ADAPTOR_LD_FLAGS "-fPIE -fPIC -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Wl,-z,relro -Wl,-z,now")
+set(HAL_ADAPTOR_LD_FLAGS "-fPIE -fPIC -Wformat -Wformat-security -Wl,-z,relro -Wl,-z,now")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${HAL_ADAPTOR_LD_FLAGS}")
 
 set(HAL_ADAPTOR_SRCS


### PR DESCRIPTION
…w the default _FORTIFY_SOURCE level in distro.

After Ubuntu 24.04, it will use -D_FORTIFY_SOURCE=3 by default for the compilation of Debian packages.