### PR TITLE
CMakeLists fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,7 +266,7 @@ add_library(camhal_static STATIC ${LIBCAMHAL_SRCS})
 if (NOT CAL_BUILD AND (NOT "${CMAKE_INSTALL_SUB_PATH}" STREQUAL ""))
     set(CMAKE_SKIP_RPATH TRUE)
     set_target_properties(camhal PROPERTIES LINK_FLAGS
-                          "-Wl,-rpath,/usr/lib/${CMAKE_INSTALL_SUB_PATH}")
+                          "-Wl,-rpath,${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/${CMAKE_INSTALL_SUB_PATH}")
     add_compile_definitions(SUB_CONFIG_PATH="${CMAKE_INSTALL_SUB_PATH}")
 endif()
 set_target_properties(camhal_static PROPERTIES OUTPUT_NAME "camhal")
@@ -399,9 +399,9 @@ endif() #ENABLE_SANDBOXING
 if (NOT CAL_BUILD)
 # Install headers
 if ("${CMAKE_INSTALL_SUB_PATH}" STREQUAL "")
-    install(DIRECTORY include/ DESTINATION usr/include/libcamhal)
+    install(DIRECTORY include/ DESTINATION include/libcamhal)
     if (SUPPORT_LIVE_TUNING)
-        install(FILES modules/livetune/LiveTuning.h DESTINATION usr/include/libcamhal/api)
+        install(FILES modules/livetune/LiveTuning.h DESTINATION include/libcamhal/api)
     endif() #SUPPORT_LIVE_TUNING
 endif()
 
@@ -421,18 +421,18 @@ endif()
 # Install libraries
 if (${CMAKE_VERSION} VERSION_LESS 3.11)
 install(TARGETS camhal camhal_static
-        LIBRARY DESTINATION usr/lib/${CMAKE_INSTALL_SUB_PATH}
-        ARCHIVE DESTINATION usr/lib/${CMAKE_INSTALL_SUB_PATH}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CMAKE_INSTALL_SUB_PATH}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CMAKE_INSTALL_SUB_PATH}
         )
 else()
-install(TARGETS camhal camhal_static DESTINATION usr/lib/${CMAKE_INSTALL_SUB_PATH})
+install(TARGETS camhal camhal_static DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CMAKE_INSTALL_SUB_PATH})
 endif()
 
 # Install package config file
 configure_file(${PROJECT_SOURCE_DIR}/cmake/libcamhal.pc.cmakein
                ${PROJECT_SOURCE_DIR}/libcamhal.pc @ONLY)
 install(FILES libcamhal.pc
-        DESTINATION usr/${CMAKE_INSTALL_LIBDIR}/${CMAKE_INSTALL_SUB_PATH}/pkgconfig)
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CMAKE_INSTALL_SUB_PATH}/pkgconfig)
 
 endif() #NOT CAL_BUILD
 


### PR DESCRIPTION
A couple of CMakeLists.txt fixes:

1. Use ${CMAKE_INSTALL_LIBDIR} instead of lib so that .so files get installed under usr/lib64 for distributions using that
2. Drop usr/ prefix in various places to avoid files getting installed under usr/usr/...