### PR TITLE
MediaControl: Dymically set mainline IVSC media-entity src-pad index

### DIFF
--- a/src/v4l2/MediaControl.cpp
+++ b/src/v4l2/MediaControl.cpp
@@ -886,6 +886,15 @@ int MediaControl::mediaCtlSetup(int cameraId, MediaCtlConf* mc, int width, int h
                              ivscName.c_str(), link.sinkEntityName.c_str());
                         link.srcEntity = ivsc->info.id;
                         link.srcEntityName = ivscName;
+                        /*
+                         * Since mainline kernel commit 48f5fd8967f8 ("media:
+                         * ivsc: csi: Swap SINK and SOURCE pads") the src-pad
+                         * on the mainline ivsc mc-entity is pad 1, where on
+                         * older versions it is pad 0, so this needs to be set
+                         * dynamically.
+                         * The src-pad is the other pad of the found ivsc sink.
+                         */
+                        link.srcPad = !ivsc->links[i].sink->index;
                         break;
                     }
                 }


### PR DESCRIPTION
Since mainline kernel commit 48f5fd8967f8 ("media: ivsc: csi: Swap SINK and SOURCE pads") the src-pad on the mainline ivsc mc-entity is pad 1, where as on older versions it is pad 0.

When updating the sensor link to point to the IVSC instead, link.srcPad was left at pad-0 inherited from the original sensor link.

Since with newer kernels this now needs to be pad-1, also update link.srcPad and do so dynamically, so that it works with all mainline IVSC driver versions.

This fixes ipu6-camera-hal / icamerasrc not working on laptops with an IVSC chip running kernels using the mainline IVSC driver with the mentioned commit.