### PR TITLE
dfsg: build: Removing duplicate make command

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -117,7 +117,7 @@ function build_hal_adaptor() {
     make -j
     check_result $? $FUNCNAME
 
-    make make DESTDIR=${INSTALL_DIR}/install install
+    make DESTDIR=${INSTALL_DIR}/install install
     check_result $? $FUNCNAME
 }
 


### PR DESCRIPTION
The build script had a redundant `make` command before the installation step.