### PR TITLE
support ov02c10 in Samsung Galaxy Book 3 Pro

### DIFF
--- a/config/linux/ipu6ep/libcamhal_profile.xml
+++ b/config/linux/ipu6ep/libcamhal_profile.xml
@@ -19,7 +19,8 @@
         <version value="1.0"/>
         <platform value="IPU6"/>
         <!-- The value format of availableSensors is "sensor name"-wf/uf-"CSI port ID" -->
-        <availableSensors value="ov13b10-wf-2,ov13b10-uf-1,ov8856-wf-2,ov8856-uf-1,ov01a10-uf-1,ov01a10-uf-2,ov02c10-uf-1,ov02c10-uf-2,
+        <availableSensors value="ov13b10-wf-2,ov13b10-uf-1,ov8856-wf-2,ov8856-uf-1,ov01a10-uf-1,ov01a10-uf-2,
+                                 ov02c10-uf-0,ov02c10-uf-1,ov02c10-uf-2,
                                  ov2740-uf-1,hm2170-uf-1,hm2170-uf-2,hi556-uf-1,ov01a1s-uf-1,ov08a10-uf-1,
                                  imx390,ar0234,external_source,ar0234_usb,lt6911uxc,lt6911uxe"/>
     </Common>


### PR DESCRIPTION
In my Samsung Galaxy Book 3 Pro (960XFG), the ov02c10 sensor is bound on CSI port 0. 
And I guess this commit also should fix the IPU6 camera problems in many laptops of the Samsung Galaxy Book series.

my dmesg log:
```
$ sudo dmesg | grep -iE 'ipu6|02c1|int34'
[    3.920345] int3472-discrete INT3472:01: power-enable \_SB.GPI0 pin number mismatch _DSM 227 resource 131
[    3.921693] int3472-discrete INT3472:01: privacy-led \_SB.GPI0 pin number mismatch _DSM 101 resource 357
[    3.923018] int3472-discrete INT3472:01: clk-enable \_SB.GPI0 pin number mismatch _DSM 246 resource 150
[    3.927463] ov02c10: module verification failed: signature and/or required key missing - tainting kernel
[    3.944194] ov02c10 i2c-OVTI02C1:00: failed to check hwcfg: -517
[    3.949366] ov02c10 i2c-OVTI02C1:00: failed to check hwcfg: -517
[    3.955211] ov02c10 i2c-OVTI02C1:00: failed to check hwcfg: -517
[    3.957398] ov02c10 i2c-OVTI02C1:00: failed to check hwcfg: -517
[    3.961490] ov02c10 i2c-OVTI02C1:00: failed to check hwcfg: -517
[    3.966605] intel-ipu6 0000:00:05.0: enabling device (0000 -> 0002)
[    3.966619] ov02c10 i2c-OVTI02C1:00: failed to check hwcfg: -517
[    3.966733] intel-ipu6 0000:00:05.0: Device 0xa75d (rev: 0x0)
[    3.966749] intel-ipu6 0000:00:05.0: physical base address 0x603c000000
[    3.966750] intel-ipu6 0000:00:05.0: mapped as: 0x000000000036c1fe
[    3.966808] intel-ipu6 0000:00:05.0: Unable to set secure mode
[    3.966812] intel-ipu6 0000:00:05.0: IPU in non-secure mode
[    3.966814] intel-ipu6 0000:00:05.0: IPU secure touch = 0x80000000
[    3.966816] intel-ipu6 0000:00:05.0: IPU camera mask = 0x0
[    3.966937] intel-ipu6 0000:00:05.0: Skip ipc reset for non-secure mode
[    3.966940] intel-ipu6 0000:00:05.0: IPC reset done
[    3.968589] intel-ipu6 0000:00:05.0: Direct firmware load for intel/ipu6ep_fw.bin failed with error -2
[    3.971723] intel-ipu6 0000:00:05.0: FW version: 20230925
[    3.972493] ov02c10 i2c-OVTI02C1:00: failed to check hwcfg: -517
[    3.973109] intel-ipu6 0000:00:05.0: Found supported sensor OVTI02C1:00
[    3.973156] intel-ipu6 0000:00:05.0: Connected 1 cameras
[    3.975203] intel-ipu6 0000:00:05.0: IPU6-v3 driver version 1.0
[    4.009520] intel-ipu6-psys intel-ipu6-psys0: pkg_dir entry count:8
[    4.009663] intel-ipu6-psys intel-ipu6-psys0: psys probe minor: 0
[    4.071791] intel-ipu6-isys intel-ipu6-isys0: bind ov02c10 0-0036 nlanes is 2 port is 0
[    4.072127] intel-ipu6-isys intel-ipu6-isys0: All sensor registration completed.
```

more details here - https://github.com/intel/ipu6-drivers/issues/228#issuecomment-2286137675