### PR TITLE
Add AR0820 and AR0830 sensor configurations for IPU6

### DIFF
--- a/config/linux/ipu6epmtl/libcamhal_profile.xml
+++ b/config/linux/ipu6epmtl/libcamhal_profile.xml
@@ -30,6 +30,7 @@
                                  imx390-5-4,imx390-6-4,ar0234-1-0,ar0234-2-4,
                                  isx031,
                                  lt6911uxc,lt6911uxe-1-0,lt6911uxe-2-4,
+                                 ar0820-1-0, ar0830-1-0, ar0830-2-4,
                                  external_source,ar0234_usb"/>
     </Common>
 </CameraSettings>

--- a/config/linux/ipu6epmtl/sensors/ar0820-1.xml
+++ b/config/linux/ipu6epmtl/sensors/ar0820-1.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Copyright (C) 2025 Intel Corporation.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<CameraSettings>
+    <Sensor name="ar0820-1" description="AR0820 GMSL (Sensing) Sensor 1" virtualChannel="true" vcGroupId="0">
+        <MediaCtlConfig id="0" mediaCfg="1" ConfigMode="AUTO" outputWidth="3840" outputHeight="2160" format="V4L2_PIX_FMT_UYVY">
+            <format name="ar0820 a" pad="0" width="3840" height="2160" format="V4L2_MBUS_FMT_UYVY8_1X16" stream="0"/>
+            <format name="max9x a-0" pad="0" width="3840" height="2160" format="V4L2_MBUS_FMT_UYVY8_1X16" stream="0"/>
+            <format name="max9x a-0" pad="2" width="3840" height="2160" format="V4L2_MBUS_FMT_UYVY8_1X16" stream="0"/>
+            <format name="max9x a" pad="0" width="3840" height="2160" format="V4L2_MBUS_FMT_UYVY8_1X16" stream="0"/>
+            <format name="max9x a" pad="4" width="3840" height="2160" format="V4L2_MBUS_FMT_UYVY8_1X16" stream="0"/>
+            <format name="Intel IPU6 CSI2 0" pad="0" width="3840" height="2160" format="V4L2_MBUS_FMT_UYVY8_1X16" stream="0"/>
+            <format name="Intel IPU6 CSI2 0" pad="1" width="3840" height="2160" format="V4L2_MBUS_FMT_UYVY8_1X16" stream="0"/>
+            <link srcName="ar0820 a" srcPad="0" sinkName="max9x a-0" sinkPad="0" enable="true"/>
+            <link srcName="max9x a-0" srcPad="2" sinkName="max9x a" sinkPad="4" enable="true"/>
+            <link srcName="max9x a" srcPad="0" sinkName="Intel IPU6 CSI2 0" sinkPad="0" enable="true"/>
+            <link srcName="Intel IPU6 CSI2 0" srcPad="1" sinkName="Intel IPU6 ISYS Capture 0" sinkPad="0" enable="true"/>
+            <route name="max9x a-0" sinkPad="0" sinkStream="0" srcPad="2" srcStream="0" flag="1"/>
+            <route name="max9x a" sinkPad="4" sinkStream="0" srcPad="0" srcStream="0" flag="1"/>
+            <route name="Intel IPU6 CSI2 0" sinkPad="0" sinkStream="0" srcPad="1" srcStream="0" flag="1"/>
+            <videonode name="Intel IPU6 ISYS Capture 0" videoNodeType="VIDEO_GENERIC"/>
+            <videonode name="Intel IPU6 CSI2 0" videoNodeType="VIDEO_ISYS_RECEIVER"/>
+            <videonode name="ar0820 a" videoNodeType="VIDEO_PIXEL_ARRAY"/>
+        </MediaCtlConfig>
+        <StaticMetadata>
+            <!-- format,widthxheight,field(none:0,alternate:7),mcId -->
+            <supportedStreamConfig value="V4L2_PIX_FMT_UYVY,3840x2160,0,0"/>
+        </StaticMetadata>
+        <supportedISysFormat value="V4L2_PIX_FMT_UYVY"/>
+        <vcAggregator value="max9x a,0"/>
+        <enableAIQ value="false"/>
+    </Sensor>
+</CameraSettings>

--- a/config/linux/ipu6epmtl/sensors/ar0830-1.xml
+++ b/config/linux/ipu6epmtl/sensors/ar0830-1.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2024 Intel Corporation.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<CameraSettings>
+    <Sensor name="ar0830-1" description="ar0830 sensor">
+        <MediaCtlConfig id="0">
+            <!-- FE capture -->
+            <format name="ar0830 1-003c" pad="0" width="3840" height="2160" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+            <format name="Intel IPU6 CSI2 0" pad="0" width="3840" height="2160" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+            <link srcName="ar0830 1-003c" srcPad="0" sinkName="Intel IPU6 CSI2 0" sinkPad="0" enable="true"/>
+            <link srcName="Intel IPU6 CSI2 0" srcPad="1" sinkName="Intel IPU6 ISYS Capture 0" sinkPad="0" enable="true"/>
+            <videonode name="Intel IPU6 ISYS Capture 0" videoNodeType="VIDEO_GENERIC"/>
+            <videonode name="Intel IPU6 CSI2 0" videoNodeType="VIDEO_ISYS_RECEIVER"/>
+            <videonode name="ar0830 1-003c" videoNodeType="VIDEO_PIXEL_ARRAY"/>
+        </MediaCtlConfig>
+        <MediaCtlConfig id="0" mediaCfg="1">
+            <!-- FE capture -->
+            <format name="ar0830 $I2CBUS" pad="0" width="3840" height="2160" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+            <format name="Intel IPU6 CSI2 $CSI_PORT" pad="0" width="3840" height="2160" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+            <link srcName="ar0830 $I2CBUS" srcPad="0" sinkName="Intel IPU6 CSI2 $CSI_PORT" sinkPad="0" enable="true"/>
+            <link srcName="Intel IPU6 CSI2 $CSI_PORT" srcPad="1" sinkName="Intel IPU6 ISYS Capture $CAPTURE_ID" sinkPad="0" enable="true"/>
+            <videonode name="Intel IPU6 ISYS Capture $CAPTURE_ID" videoNodeType="VIDEO_GENERIC"/>
+            <videonode name="Intel IPU6 CSI2 $CSI_PORT" videoNodeType="VIDEO_ISYS_RECEIVER"/>
+            <videonode name="ar0830 $I2CBUS" videoNodeType="VIDEO_PIXEL_ARRAY"/>
+        </MediaCtlConfig>
+        <StaticMetadata>
+            <!-- list of stream config info. Meanings of each part is "format,widthxheight,field(0 is none, 7 is alternate),mcId" -->
+            <supportedStreamConfig value="V4L2_PIX_FMT_UYVY,3840x2160,0,0"/>
+            <fpsRange value="10,30"/>
+        </StaticMetadata>
+        <supportedISysSizes value="3840x2160"/>
+        <!-- ascending order request-->
+        <supportedISysFormat value="V4L2_PIX_FMT_UYVY"/>
+        <enableAIQ value="false"/>
+        <resetLinkRoute value="false"/>
+    </Sensor>
+</CameraSettings>

--- a/config/linux/ipu6epmtl/sensors/ar0830-2.xml
+++ b/config/linux/ipu6epmtl/sensors/ar0830-2.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2024 Intel Corporation.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<CameraSettings>
+    <Sensor name="ar0830-2" description="ar0830 sensor">
+        <MediaCtlConfig id="0">
+            <!-- FE capture -->
+            <format name="ar0830 0-003c" pad="0" width="3840" height="2160" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+            <format name="Intel IPU6 CSI2 4" pad="0" width="3840" height="2160" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+            <link srcName="ar0830 0-003c" srcPad="0" sinkName="Intel IPU6 CSI2 4" sinkPad="0" enable="true"/>
+            <link srcName="Intel IPU6 CSI2 4" srcPad="1" sinkName="Intel IPU6 ISYS Capture 32" sinkPad="0" enable="true"/>
+            <videonode name="Intel IPU6 ISYS Capture 32" videoNodeType="VIDEO_GENERIC"/>
+            <videonode name="Intel IPU6 CSI2 4" videoNodeType="VIDEO_ISYS_RECEIVER"/>
+            <videonode name="ar0830 0-003c" videoNodeType="VIDEO_PIXEL_ARRAY"/>
+        </MediaCtlConfig>
+        <MediaCtlConfig id="0" mediaCfg="1">
+            <!-- FE capture -->
+            <format name="ar0830 $I2CBUS" pad="0" width="3840" height="2160" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+            <format name="Intel IPU6 CSI2 $CSI_PORT" pad="0" width="3840" height="2160" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+            <link srcName="ar0830 $I2CBUS" srcPad="0" sinkName="Intel IPU6 CSI2 $CSI_PORT" sinkPad="0" enable="true"/>
+            <link srcName="Intel IPU6 CSI2 $CSI_PORT" srcPad="1" sinkName="Intel IPU6 ISYS Capture $CAPTURE_ID" sinkPad="0" enable="true"/>
+            <videonode name="Intel IPU6 ISYS Capture $CAPTURE_ID" videoNodeType="VIDEO_GENERIC"/>
+            <videonode name="Intel IPU6 CSI2 $CSI_PORT" videoNodeType="VIDEO_ISYS_RECEIVER"/>
+            <videonode name="ar0830 $I2CBUS" videoNodeType="VIDEO_PIXEL_ARRAY"/>
+        </MediaCtlConfig>
+        <StaticMetadata>
+            <!-- list of stream config info. Meanings of each part is "format,widthxheight,field(0 is none, 7 is alternate),mcId" -->
+            <supportedStreamConfig value="V4L2_PIX_FMT_UYVY,3840x2160,0,0"/>
+            <fpsRange value="10,30"/>
+        </StaticMetadata>
+        <supportedISysSizes value="3840x2160"/>
+        <!-- ascending order request-->
+        <supportedISysFormat value="V4L2_PIX_FMT_UYVY"/>
+        <enableAIQ value="false"/>
+        <resetLinkRoute value="false"/>
+    </Sensor>
+</CameraSettings>


### PR DESCRIPTION
Add support for AR0820 and AR0830 sensors:
- Add AR0820-1 sensor configuration (GMSL, 3840x2160 UYVY)
- Add AR0830-1 sensor configuration (3840x2160 UYVY)
- Add AR0830-2 sensor configuration (3840x2160 UYVY)
- Register new sensors in libcamhal_profile.xml

These configurations enable camera HAL support for AR0820 and AR0830 sensors on Intel IPU6 EPMTL platform with proper media controller pipeline setup and V4L2 format definitions.