### PR TITLE
Fix ov2740 config, add missing reqWaitTimeoutNs and disable flaky AE-based privacy

### DIFF
--- a/config/linux/ipu6ep/sensors/ov2740-uf.xml
+++ b/config/linux/ipu6ep/sensors/ov2740-uf.xml
@@ -93,8 +93,9 @@
         <enableAiqd value = "true"/>
         <useCrlModule value = "false"/>
         <maxRequestsInflight value="6"/>
-        <supportPrivacy value="2"/> <!-- privacy mode, 0: off, 1: CVF privacy 2: AE-based privacy -->
+        <supportPrivacy value="0"/> <!-- privacy mode, 0: off, 1: CVF privacy 2: AE-based privacy -->
         <privacyModeThreshold value="10"/> <!-- AE-based privacy mode luminance threshold -->
         <privacyModeFrameDelay value="5"/> <!-- AE-based privacy mode frame delay -->
+        <reqWaitTimeoutNs value="2000000000"/>
     </Sensor>
 </CameraSettings>


### PR DESCRIPTION
This PR changes two configuration options in the XML sensor configuration file for the OV2740 sensor on the ipu6ep platform:                                                                                                                      
                                                                                                                                                                                                                                                    
  - `reqWaitTimeoutNs` is added with the same value as all the other sensors have. This prevents the v4l2loopback service from entering an infinite retry loop when the sensor fails to produce frames on first boot — without this field,                    
  `CameraDevice::dqbuf()` falls into a `while (ret == TIMED_OUT)` spin instead of propagating the error.
  - `supportPrivacy` is disabled (0), as AE-based privacy detection causes false-positive stream shutdowns on my system, where brief dark frames during pipeline init and low-light scenes repeatedly trip the luminance threshold and halt the camera.
  
  Related: https://github.com/NixOS/nixpkgs/issues/225743#issuecomment-4347808404