### PR TITLE
Support BGGR/RGGB/GBRG bayer orders in the PSYS pipeline

### DIFF
--- a/src/core/psysprocessor/PGUtils.cpp
+++ b/src/core/psysprocessor/PGUtils.cpp
@@ -232,6 +232,9 @@ int getStride(int cssFmt, int width) {
     int stride = width;
     switch (cssFmt) {
         case IA_CSS_DATA_FORMAT_BAYER_GRBG:  // GR10
+        case IA_CSS_DATA_FORMAT_BAYER_BGGR:  // BG10 (e.g. OV5693 with sensor vflip)
+        case IA_CSS_DATA_FORMAT_BAYER_RGGB:
+        case IA_CSS_DATA_FORMAT_BAYER_GBRG:
         case IA_CSS_DATA_FORMAT_RAW:         // BA10
             stride = ALIGN_64(width * 2);
             break;

--- a/src/core/psysprocessor/PipeLiteExecutor.cpp
+++ b/src/core/psysprocessor/PipeLiteExecutor.cpp
@@ -506,7 +506,8 @@ bool PipeLiteExecutor::isSameStreamConfig(const stream_t& internal, const stream
      *     PG use its kernel to crop to GRBG
      */
     if ((internalFormat == V4L2_PIX_FMT_SGRBG10 || internalFormat == V4L2_PIX_FMT_SGRBG12) &&
-        (external.format == V4L2_PIX_FMT_SRGGB10 || external.format == V4L2_PIX_FMT_SRGGB12)) {
+        (external.format == V4L2_PIX_FMT_SRGGB10 || external.format == V4L2_PIX_FMT_SRGGB12 ||
+         external.format == V4L2_PIX_FMT_SBGGR10 || external.format == V4L2_PIX_FMT_SBGGR12)) {
         return true;
     }
 

--- a/src/iutils/Utils.cpp
+++ b/src/iutils/Utils.cpp
@@ -392,6 +392,9 @@ int32_t CameraUtils::getBpl(int32_t format, int32_t width) {
         case GET_FOURCC_FMT('b', 'V', '0', 'K'):  // BV0K
         case GET_FOURCC_FMT('B', 'A', '1', '0'):  // BA10
         case GET_FOURCC_FMT('G', 'R', '1', '0'):  // GR10
+        case GET_FOURCC_FMT('B', 'G', '1', '0'):  // BG10 (BGGR bayer, e.g. OV5693 vflip)
+        case GET_FOURCC_FMT('R', 'G', '1', '0'):  // RG10
+        case GET_FOURCC_FMT('G', 'B', '1', '0'):  // GB10
         case GET_FOURCC_FMT('B', 'A', '1', '2'):  // BA12
         case GET_FOURCC_FMT('P', '0', '1', '0'):  // P010
         case GET_FOURCC_FMT('P', '0', '1', 'L'):  // P010_LSB


### PR DESCRIPTION
The HAL currently only handles GRBG bayer input in three spots, which breaks any sensor advertising another bayer order. We hit this bringing up the Surface Pro 7+ front camera (OV5693, SBGGR10 in its 2x2-binned mode) on the mainline `intel-ipu6` ISYS:

1. `PGUtils::getStride()` — unknown bayer formats fall through to an unaligned stride and the PG aborts with a firmware assert in `dma_nci_io` (`stride % 64`).
2. `CameraUtils::getBpl()` — `BG10`/`RG10`/`GB10` fourccs missing → wrong bytes-per-line → vertically striped image.
3. `PipeLiteExecutor::isSameStreamConfig()` — the SBGGR external stream never matches the internal SGRBG one, so input ports fail to bind.

This adds the missing bayer orders alongside the existing GRBG cases (no behavior change for currently supported sensors). Verified end-to-end on a Surface Pro 7+ (IPU6 Tiger Lake): with these three changes the full sensor → ISYS → PSYS pipeline runs at 30 fps with correct output. Full bring-up documented at https://github.com/dmanresa-saes/surface-ipu6-cameras.